### PR TITLE
Prevent debug statements from excessively logging

### DIFF
--- a/jira/table_jira_issue.go
+++ b/jira/table_jira_issue.go
@@ -293,8 +293,8 @@ func listIssues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 				plugin.Logger(ctx).Debug("Maximum number of issues reached", issueLimit)
 				return nil, nil
 			}
-			plugin.Logger(ctx).Debug("Issue output:", issue)
-			plugin.Logger(ctx).Debug("Issue names output:", names)
+			// plugin.Logger(ctx).Debug("Issue output:", issue)
+			// plugin.Logger(ctx).Debug("Issue names output:", names)
 			keys := map[string]string{
 				"epic":   getFieldKey(ctx, d, names, "Epic Link"),
 				"sprint": getFieldKey(ctx, d, names, "Sprint"),
@@ -435,7 +435,7 @@ func getIssueTags(_ context.Context, d *transform.TransformData) (interface{}, e
 // getFieldKey:: get key for unknown expanded fields
 func getFieldKey(ctx context.Context, d *plugin.QueryData, names map[string]string, keyName string) string {
 
-	plugin.Logger(ctx).Debug("Check for keyName", names)
+	// plugin.Logger(ctx).Debug("Check for keyName", names)
 	cacheKey := "issue-" + keyName
 	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
 		return cachedData.(string)


### PR DESCRIPTION
Comment out a few lines which cause excessive logging and strain on the system.